### PR TITLE
chore: Change name used on QuayIO environment variable and for `client` in test and examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
       # - name: Run cargo test (test-net-private)
       #   run: cargo test --features test-net,test-net-private
       #   env:
-      #     DKREG_QUAY_USER: ${{ secrets.DKREG_QUAY_USER }}
-      #     DKREG_QUAY_PASSWD: ${{ secrets.DKREG_QUAY_PASSWD }}
+      #     DOCKER_REGISTRY_QUAY_USER: ${{ secrets.DOCKER_REGISTRY_QUAY_USER }}
+      #     DOCKER_REGISTRY_QUAY_PASSWD: ${{ secrets.DOCKER_REGISTRY_QUAY_PASSWD }}
 
   lints:
     name: Lints

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ url = "2.5"
 
 [dev-dependencies]
 dirs = "5.0"
-env_logger = "0.11"
 hyper = "1.4"
 mockito = "1.5"
 native-tls = "0.2"
 test-case = "3.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [features]
 default = ["reqwest-default-tls"]

--- a/examples/checkregistry.rs
+++ b/examples/checkregistry.rs
@@ -18,12 +18,12 @@ async fn main() {
 }
 
 async fn run(host: &str) -> Result<bool, boxed::Box<dyn error::Error>> {
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(host)
     .insecure_registry(false)
     .build()?;
 
-  let supported = dclient.is_v2_supported().await?;
+  let supported = client.is_v2_supported().await?;
   if supported {
     info!("{host} supports v2");
   } else {

--- a/examples/checkregistry.rs
+++ b/examples/checkregistry.rs
@@ -4,6 +4,11 @@ use tracing::{error, info};
 
 #[tokio::main]
 async fn main() {
+  tracing_subscriber::fmt()
+    .pretty()
+    .with_max_level(tracing::Level::INFO)
+    .init();
+
   let registry = match std::env::args().nth(1) {
     Some(x) => x,
     None => "registry-1.docker.io".into(),

--- a/examples/image-labels.rs
+++ b/examples/image-labels.rs
@@ -27,13 +27,13 @@ async fn main() {
       warn!("[{registry}] no credentials found in config.json");
     }
   } else {
-    user = env::var("DKREG_USER").ok();
+    user = env::var("DOCKER_REGISTRY_USER").ok();
     if user.is_none() {
-      warn!("[{registry}] no $DKREG_USER for login user");
+      warn!("[{registry}] no $DOCKER_REGISTRY_USER for login user");
     }
-    password = env::var("DKREG_PASSWD").ok();
+    password = env::var("DOCKER_REGISTRY_PASSWD").ok();
     if password.is_none() {
-      warn!("[{registry}] no $DKREG_PASSWD for login password");
+      warn!("[{registry}] no $DOCKER_REGISTRY_PASSWD for login password");
     }
   };
 
@@ -61,8 +61,8 @@ async fn run(
   let login_scope = format!("repository:{image}:pull");
   let version = dkr_ref.version();
 
-  let dclient = client.authenticate(&[&login_scope]).await?;
-  let manifest = dclient.get_manifest(&image, &version).await?;
+  let client = client.authenticate(&[&login_scope]).await?;
+  let manifest = client.get_manifest(&image, &version).await?;
 
   if let Manifest::S1Signed(s1s) = manifest {
     let labels = s1s.get_labels(0);

--- a/examples/image-labels.rs
+++ b/examples/image-labels.rs
@@ -5,6 +5,11 @@ use tracing::{error, info, warn};
 
 #[tokio::main]
 async fn main() {
+  tracing_subscriber::fmt()
+    .pretty()
+    .with_max_level(tracing::Level::INFO)
+    .init();
+
   let dkr_ref = match std::env::args().nth(1) {
     Some(ref x) => reference::Reference::from_str(x),
     None => reference::Reference::from_str("quay.io/steveej/cincinnati-test-labels:0.0.0"),

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -77,10 +77,10 @@ async fn run(
   passwd: Option<String>,
   path: &Path,
 ) -> Result<(), boxed::Box<dyn error::Error>> {
-  env_logger::Builder::new()
-    .filter(Some("docker_registry"), log::LevelFilter::Trace)
-    .filter(Some("trace"), log::LevelFilter::Trace)
-    .try_init()?;
+  tracing_subscriber::fmt()
+    .pretty()
+    .with_max_level(tracing::Level::INFO)
+    .init();
 
   let client = docker_registry::v2::Client::configure()
     .registry(registry)

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -49,13 +49,13 @@ async fn main() -> Result<(), boxed::Box<dyn error::Error>> {
       warn!("[{registry}] no credentials found in config.json");
     }
   } else {
-    user = env::var("DKREG_USER").ok();
+    user = env::var("DOCKER_REGISTRY_USER").ok();
     if user.is_none() {
-      warn!("[{registry}] no $DKREG_USER for login user");
+      warn!("[{registry}] no $DOCKER_REGISTRY_USER for login user");
     }
-    password = env::var("DKREG_PASSWD").ok();
+    password = env::var("DOCKER_REGISTRY_PASSWD").ok();
     if password.is_none() {
-      warn!("[{registry}] no $DKREG_PASSWD for login password");
+      warn!("[{registry}] no $DOCKER_REGISTRY_PASSWD for login password");
     }
   };
 
@@ -91,15 +91,15 @@ async fn run(
 
   let login_scope = format!("repository:{image}:pull");
 
-  let dclient = client.authenticate(&[&login_scope]).await?;
-  let manifest = dclient.get_manifest(image, version).await?;
+  let client = client.authenticate(&[&login_scope]).await?;
+  let manifest = client.get_manifest(image, version).await?;
   let layers_digests = manifest.layers_digests(None)?;
 
   info!("{} -> got {} layer(s)", &image, layers_digests.len(),);
 
   let blob_futures = layers_digests
     .iter()
-    .map(|layer_digest| dclient.get_blob(image, layer_digest))
+    .map(|layer_digest| client.get_blob(image, layer_digest))
     .collect::<Vec<_>>();
 
   let blobs = try_join_all(blob_futures).await?;

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -14,13 +14,13 @@ async fn main() {
     None => "".into(),
   };
 
-  let user = std::env::var("DKREG_USER").ok();
+  let user = std::env::var("DOCKER_REGISTRY_USER").ok();
   if user.is_none() {
-    warn!("[{registry}] no $DKREG_USER for login user");
+    warn!("[{registry}] no $DOCKER_REGISTRY_USER for login user");
   }
-  let password = std::env::var("DKREG_PASSWD").ok();
+  let password = std::env::var("DOCKER_REGISTRY_PASSWD").ok();
   if password.is_none() {
-    warn!("[{registry}] no $DKREG_PASSWD for login password");
+    warn!("[{registry}] no $DOCKER_REGISTRY_PASSWD for login password");
   }
 
   let res = run(&registry, user, password, login_scope).await;
@@ -49,7 +49,7 @@ async fn run(
     .password(passwd)
     .build()?;
 
-  let dclient = client.authenticate(&[&login_scope]).await?;
-  dclient.is_auth().await?;
+  let client = client.authenticate(&[&login_scope]).await?;
+  client.is_auth().await?;
   Ok(())
 }

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -4,6 +4,11 @@ use tracing::{error, warn};
 
 #[tokio::main]
 async fn main() {
+  tracing_subscriber::fmt()
+    .pretty()
+    .with_max_level(tracing::Level::INFO)
+    .init();
+
   let registry = match std::env::args().nth(1) {
     Some(x) => x,
     None => "registry-1.docker.io".into(),
@@ -37,11 +42,6 @@ async fn run(
   passwd: Option<String>,
   login_scope: String,
 ) -> Result<(), boxed::Box<dyn error::Error>> {
-  env_logger::Builder::new()
-    .filter(Some("docker_registry"), log::LevelFilter::Trace)
-    .filter(Some("trace"), log::LevelFilter::Trace)
-    .try_init()?;
-
   let client = docker_registry::v2::Client::configure()
     .registry(host)
     .insecure_registry(false)

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -5,6 +5,11 @@ use tracing::{error, info, warn};
 
 #[tokio::main]
 async fn main() {
+  tracing_subscriber::fmt()
+    .pretty()
+    .with_max_level(tracing::Level::INFO)
+    .init();
+
   let registry = match std::env::args().nth(1) {
     Some(x) => x,
     None => "registry-1.docker.io".into(),
@@ -39,11 +44,6 @@ async fn run(
   passwd: Option<String>,
   image: &str,
 ) -> Result<(), boxed::Box<dyn error::Error>> {
-  env_logger::Builder::new()
-    .filter(Some("docker_registry"), log::LevelFilter::Trace)
-    .filter(Some("trace"), log::LevelFilter::Trace)
-    .try_init()?;
-
   let client = docker_registry::v2::Client::configure()
     .registry(host)
     .insecure_registry(false)

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -16,13 +16,13 @@ async fn main() {
   };
   info!("[{registry}] requesting tags for image {image}");
 
-  let user = std::env::var("DKREG_USER").ok();
+  let user = std::env::var("DOCKER_REGISTRY_USER").ok();
   if user.is_none() {
-    warn!("[{registry}] no $DKREG_USER for login user");
+    warn!("[{registry}] no $DOCKER_REGISTRY_USER for login user");
   }
-  let password = std::env::var("DKREG_PASSWD").ok();
+  let password = std::env::var("DOCKER_REGISTRY_PASSWD").ok();
   if password.is_none() {
-    warn!("[{registry}] no $DKREG_PASSWD for login password");
+    warn!("[{registry}] no $DOCKER_REGISTRY_PASSWD for login password");
   }
 
   let res = run(&registry, user, password, &image).await;
@@ -53,9 +53,9 @@ async fn run(
 
   let login_scope = format!("repository:{image}:pull");
 
-  let dclient = client.authenticate(&[&login_scope]).await?;
+  let client = client.authenticate(&[&login_scope]).await?;
 
-  dclient
+  client
     .get_tags(image, Some(7))
     .collect::<Vec<_>>()
     .await

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -5,6 +5,11 @@ use tracing::{error, info, warn};
 
 #[tokio::main]
 async fn main() {
+  tracing_subscriber::fmt()
+    .pretty()
+    .with_max_level(tracing::Level::INFO)
+    .init();
+
   let dkr_ref = match std::env::args().nth(1) {
     Some(ref x) => reference::Reference::from_str(x),
     None => reference::Reference::from_str("quay.io/coreos/etcd"),
@@ -50,11 +55,6 @@ async fn run(
   user: Option<String>,
   passwd: Option<String>,
 ) -> Result<(), boxed::Box<dyn error::Error>> {
-  env_logger::Builder::new()
-    .filter(Some("docker_registry"), log::LevelFilter::Trace)
-    .filter(Some("trace"), log::LevelFilter::Trace)
-    .try_init()?;
-
   let image = dkr_ref.repository();
   let version = dkr_ref.version();
 

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -27,13 +27,13 @@ async fn main() {
       warn!("[{registry}] no credentials found in config.json");
     }
   } else {
-    user = env::var("DKREG_USER").ok();
+    user = env::var("DOCKER_REGISTRY_USER").ok();
     if user.is_none() {
-      warn!("[{registry}] no $DKREG_USER for login user");
+      warn!("[{registry}] no $DOCKER_REGISTRY_USER for login user");
     }
-    password = env::var("DKREG_PASSWD").ok();
+    password = env::var("DOCKER_REGISTRY_PASSWD").ok();
     if password.is_none() {
-      warn!("[{registry}] no $DKREG_PASSWD for login password");
+      warn!("[{registry}] no $DOCKER_REGISTRY_PASSWD for login password");
     }
   };
 
@@ -67,14 +67,14 @@ async fn run(
 
   let login_scope = "";
 
-  let dclient = client.authenticate(&[login_scope]).await?;
-  let manifest = dclient.get_manifest(&image, &version).await?;
+  let client = client.authenticate(&[login_scope]).await?;
+  let manifest = client.get_manifest(&image, &version).await?;
 
   let layers_digests = manifest.layers_digests(None)?;
   info!("{} -> got {} layer(s)", &image, layers_digests.len(),);
 
   for layer_digest in &layers_digests {
-    let blob = dclient.get_blob(&image, layer_digest).await?;
+    let blob = client.get_blob(&image, layer_digest).await?;
     info!("Layer {layer_digest}, got {} bytes.", blob.len());
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,11 @@
 //!
 //! // Check whether a registry supports API v2.
 //! let host = "quay.io";
-//! let dclient = Client::configure()
+//! let client = Client::configure()
 //!   .insecure_registry(false)
 //!   .registry(host)
 //!   .build()?;
-//! match dclient.is_v2_supported().await? {
+//! match client.is_v2_supported().await? {
 //!   false => println!("{} does NOT support v2", host),
 //!   true => println!("{} supports v2", host),
 //! };

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -16,8 +16,8 @@
 //! use docker_registry::v2::Client;
 //!
 //! // Retrieve an image manifest.
-//! let dclient = Client::configure().registry("quay.io").build()?;
-//! let manifest = dclient.get_manifest("coreos/etcd", "v3.1.0").await?;
+//! let client = Client::configure().registry("quay.io").build()?;
+//! let manifest = client.get_manifest("coreos/etcd", "v3.1.0").await?;
 //! #
 //! # Ok(())
 //! # };

--- a/tests/mock/api_version.rs
+++ b/tests/mock/api_version.rs
@@ -12,7 +12,7 @@ async fn test_version_check_status_ok() {
     .with_header(API_VERSION_K, API_VERSION_V)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -20,16 +20,16 @@ async fn test_version_check_status_ok() {
     .build()
     .unwrap();
 
-  let ok = dclient.is_v2_supported().await.unwrap();
+  let ok = client.is_v2_supported().await.unwrap();
 
   mock.assert_async().await;
   assert!(ok);
 
-  let _ensure_v2 = dclient.ensure_v2_registry().await.unwrap();
+  let _ensure_v2 = client.ensure_v2_registry().await.unwrap();
 }
 
 #[tokio::test]
-async fn test_version_check_status_unauth() {
+async fn test_version_check_status_no_auth() {
   let mut server = mockito::Server::new_async().await;
   let addr = server.host_with_port();
 
@@ -39,7 +39,7 @@ async fn test_version_check_status_unauth() {
     .with_header(API_VERSION_K, API_VERSION_V)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -47,14 +47,14 @@ async fn test_version_check_status_unauth() {
     .build()
     .unwrap();
 
-  let res = dclient.is_v2_supported().await.unwrap();
+  let res = client.is_v2_supported().await.unwrap();
 
   mock.assert_async().await;
   assert!(res);
 }
 
 #[tokio::test]
-async fn test_version_check_status_notfound() {
+async fn test_version_check_status_not_found() {
   let mut server = mockito::Server::new_async().await;
   let addr = server.host_with_port();
 
@@ -64,7 +64,7 @@ async fn test_version_check_status_notfound() {
     .with_header(API_VERSION_K, API_VERSION_V)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -72,7 +72,7 @@ async fn test_version_check_status_notfound() {
     .build()
     .unwrap();
 
-  let res = dclient.is_v2_supported().await.unwrap();
+  let res = client.is_v2_supported().await.unwrap();
 
   mock.assert_async().await;
   assert!(!res);
@@ -89,7 +89,7 @@ async fn test_version_check_status_forbidden() {
     .with_header(API_VERSION_K, API_VERSION_V)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -97,19 +97,19 @@ async fn test_version_check_status_forbidden() {
     .build()
     .unwrap();
 
-  let res = dclient.is_v2_supported().await.unwrap();
+  let res = client.is_v2_supported().await.unwrap();
 
   mock.assert_async().await;
   assert!(!res);
 }
 
 #[tokio::test]
-async fn test_version_check_noheader() {
+async fn test_version_check_no_header() {
   let mut server = mockito::Server::new_async().await;
   let addr = server.host_with_port();
   let mock = server.mock("GET", "/v2/").with_status(403).create_async().await;
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -117,7 +117,7 @@ async fn test_version_check_noheader() {
     .build()
     .unwrap();
 
-  let res = dclient.is_v2_supported().await.unwrap();
+  let res = client.is_v2_supported().await.unwrap();
 
   mock.assert_async().await;
   assert!(!res);
@@ -134,7 +134,7 @@ async fn test_version_check_trailing_slash() {
     .with_header(API_VERSION_K, API_VERSION_V)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -142,7 +142,7 @@ async fn test_version_check_trailing_slash() {
     .build()
     .unwrap();
 
-  let res = dclient.is_v2_supported().await.unwrap();
+  let res = client.is_v2_supported().await.unwrap();
 
   // TODO - why does this fail?
   // mock.assert_async().await;

--- a/tests/mock/base_client.rs
+++ b/tests/mock/base_client.rs
@@ -13,7 +13,7 @@ async fn test_base_no_insecure() {
     .with_header(API_VERSION_K, API_VERSION_V)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(false)
     .username(None)
@@ -21,7 +21,7 @@ async fn test_base_no_insecure() {
     .build()
     .unwrap();
 
-  let res = dclient.is_v2_supported().await.unwrap();
+  let res = client.is_v2_supported().await.unwrap();
 
   // This relies on the fact that mockito is HTTP-only and
   // trying to speak TLS to it results in garbage/errors.
@@ -41,7 +41,7 @@ async fn test_base_useragent() {
     .with_header(API_VERSION_K, API_VERSION_V)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -49,7 +49,7 @@ async fn test_base_useragent() {
     .build()
     .unwrap();
 
-  let res = dclient.is_v2_supported().await.unwrap();
+  let res = client.is_v2_supported().await.unwrap();
 
   mock.assert_async().await;
   assert!(res);
@@ -69,7 +69,7 @@ async fn test_base_custom_useragent() {
     .with_header(API_VERSION_K, API_VERSION_V)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .user_agent(Some(ua.to_string()))
@@ -78,7 +78,7 @@ async fn test_base_custom_useragent() {
     .build()
     .unwrap();
 
-  let res = dclient.is_v2_supported().await.unwrap();
+  let res = client.is_v2_supported().await.unwrap();
 
   mock.assert_async().await;
   assert!(res);

--- a/tests/mock/blobs_download.rs
+++ b/tests/mock/blobs_download.rs
@@ -20,7 +20,7 @@ async fn test_blobs_has_layer() {
     .with_header("Docker-Content-Digest", binary_digest)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -28,7 +28,7 @@ async fn test_blobs_has_layer() {
     .build()
     .unwrap();
 
-  let res = dclient.has_blob(name, digest).await.unwrap();
+  let res = client.has_blob(name, digest).await.unwrap();
 
   mock.assert_async().await;
   assert!(res);
@@ -45,7 +45,7 @@ async fn test_blobs_hasnot_layer() {
 
   let mock = server.mock("HEAD", ep.as_str()).with_status(404).create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -53,7 +53,7 @@ async fn test_blobs_hasnot_layer() {
     .build()
     .unwrap();
 
-  let res = dclient.has_blob(name, digest).await.unwrap();
+  let res = client.has_blob(name, digest).await.unwrap();
 
   mock.assert_async().await;
   assert!(!res);
@@ -75,7 +75,7 @@ async fn get_blobs_succeeds_with_consistent_layer() -> Fallible<()> {
     .with_body(blob)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -83,7 +83,7 @@ async fn get_blobs_succeeds_with_consistent_layer() -> Fallible<()> {
     .build()
     .unwrap();
 
-  let res = dclient.get_blob(name, &digest).await.unwrap();
+  let res = client.get_blob(name, &digest).await.unwrap();
 
   mock.assert_async().await;
   assert_eq!(blob, res.as_slice());
@@ -108,7 +108,7 @@ async fn get_blobs_fails_with_inconsistent_layer() -> Fallible<()> {
     .with_body(blob2)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -116,7 +116,7 @@ async fn get_blobs_fails_with_inconsistent_layer() -> Fallible<()> {
     .build()
     .unwrap();
 
-  match dclient.get_blob(name, &digest).await {
+  match client.get_blob(name, &digest).await {
     Ok(_) => panic!("Expected error"),
     Err(e) => assert_eq!(e.to_string(), "content digest error"),
   }
@@ -142,7 +142,7 @@ async fn get_blobs_stream() -> Fallible<()> {
     .with_body(blob)
     .create();
 
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -150,7 +150,7 @@ async fn get_blobs_stream() -> Fallible<()> {
     .build()
     .unwrap();
 
-  let res = dclient.get_blob_response(name, &digest).await.unwrap();
+  let res = client.get_blob_response(name, &digest).await.unwrap();
 
   mock.assert_async().await;
   assert_eq!(res.size(), Some(5));

--- a/tests/mock/catalog.rs
+++ b/tests/mock/catalog.rs
@@ -16,7 +16,7 @@ fn test_catalog_simple() {
     .create();
 
   let runtime = Runtime::new().unwrap();
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -24,7 +24,7 @@ fn test_catalog_simple() {
     .build()
     .unwrap();
 
-  let futcheck = dclient.get_catalog(None);
+  let futcheck = client.get_catalog(None);
   let res = runtime.block_on(futcheck.map(Result::unwrap).collect::<Vec<_>>());
 
   mock.assert();
@@ -50,7 +50,7 @@ fn test_catalog_paginate() {
     .create();
 
   let runtime = Runtime::new().unwrap();
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -58,7 +58,7 @@ fn test_catalog_paginate() {
     .build()
     .unwrap();
 
-  let next = Box::pin(dclient.get_catalog(Some(1)));
+  let next = Box::pin(client.get_catalog(Some(1)));
 
   let (page1, next) = runtime.block_on(next.into_future());
   assert_eq!(page1.unwrap().unwrap(), "r1/i1".to_owned());

--- a/tests/mock/tags_dockerv2.rs
+++ b/tests/mock/tags_dockerv2.rs
@@ -18,7 +18,7 @@ fn test_dockerv2_tags_simple() {
     .create();
 
   let runtime = Runtime::new().unwrap();
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -26,7 +26,7 @@ fn test_dockerv2_tags_simple() {
     .build()
     .unwrap();
 
-  let futcheck = dclient.get_tags(name, None);
+  let futcheck = client.get_tags(name, None);
 
   let res = runtime.block_on(futcheck.map(Result::unwrap).collect::<Vec<_>>());
   mock.assert();
@@ -60,7 +60,7 @@ fn test_dockerv2_tags_paginate() {
     .create();
 
   let runtime = Runtime::new().unwrap();
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -68,7 +68,7 @@ fn test_dockerv2_tags_paginate() {
     .build()
     .unwrap();
 
-  let next = Box::pin(dclient.get_tags(name, Some(1)).map(Result::unwrap));
+  let next = Box::pin(client.get_tags(name, Some(1)).map(Result::unwrap));
 
   let (first_tag, stream_rest) = runtime.block_on(next.into_future());
   assert_eq!(first_tag.unwrap(), "t1".to_owned());
@@ -100,7 +100,7 @@ fn test_dockerv2_tags_404() {
     .create();
 
   let runtime = Runtime::new().unwrap();
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -108,7 +108,7 @@ fn test_dockerv2_tags_404() {
     .build()
     .unwrap();
 
-  let futcheck = dclient.get_tags(name, None);
+  let futcheck = client.get_tags(name, None);
 
   let res = runtime.block_on(futcheck.collect::<Vec<_>>());
   mock.assert();
@@ -131,7 +131,7 @@ fn test_dockerv2_tags_missing_header() {
     .create();
 
   let runtime = Runtime::new().unwrap();
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -139,7 +139,7 @@ fn test_dockerv2_tags_missing_header() {
     .build()
     .unwrap();
 
-  let futcheck = dclient.get_tags(name, None);
+  let futcheck = client.get_tags(name, None);
 
   let res = runtime.block_on(futcheck.map(Result::unwrap).collect::<Vec<_>>());
   mock.assert();

--- a/tests/mock/tags_quay.rs
+++ b/tests/mock/tags_quay.rs
@@ -18,7 +18,7 @@ fn test_quay_tags_simple() {
     .create();
 
   let runtime = Runtime::new().unwrap();
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -26,7 +26,7 @@ fn test_quay_tags_simple() {
     .build()
     .unwrap();
 
-  let futcheck = dclient.get_tags(name, None);
+  let futcheck = client.get_tags(name, None);
 
   let res = runtime.block_on(futcheck.map(Result::unwrap).collect::<Vec<_>>());
   assert_eq!(res.first().unwrap(), &String::from("t1"));
@@ -60,7 +60,7 @@ fn test_quay_tags_paginate() {
     .create();
 
   let runtime = Runtime::new().unwrap();
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -68,7 +68,7 @@ fn test_quay_tags_paginate() {
     .build()
     .unwrap();
 
-  let next = Box::pin(dclient.get_tags(name, Some(1)).map(Result::unwrap));
+  let next = Box::pin(client.get_tags(name, Some(1)).map(Result::unwrap));
 
   let (first_tag, stream_rest) = runtime.block_on(next.into_future());
   assert_eq!(first_tag.unwrap(), "t1".to_owned());
@@ -100,7 +100,7 @@ fn test_quay_tags_404() {
     .create();
 
   let runtime = Runtime::new().unwrap();
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -108,7 +108,7 @@ fn test_quay_tags_404() {
     .build()
     .unwrap();
 
-  let futcheck = dclient.get_tags(name, None);
+  let futcheck = client.get_tags(name, None);
 
   let res = runtime.block_on(futcheck.collect::<Vec<_>>());
   assert!(res.first().unwrap().is_err());
@@ -131,7 +131,7 @@ fn test_quay_tags_missing_header() {
     .create();
 
   let runtime = Runtime::new().unwrap();
-  let dclient = docker_registry::v2::Client::configure()
+  let client = docker_registry::v2::Client::configure()
     .registry(&addr)
     .insecure_registry(true)
     .username(None)
@@ -139,7 +139,7 @@ fn test_quay_tags_missing_header() {
     .build()
     .unwrap();
 
-  let futcheck = dclient.get_tags(name, None);
+  let futcheck = client.get_tags(name, None);
 
   let res = runtime.block_on(futcheck.map(Result::unwrap).collect::<Vec<_>>());
   assert_eq!(vec!["t1", "t2"], res);


### PR DESCRIPTION
## Description
- Change name used on QuayIO environment variable and for `client` in test and examples

## Motivation and Context
- Name update
- Exercise CI changes

## How Has This Been Tested?
- CI

## Screenshots (if appropriate):
