### PR TITLE
Support zstd-decompression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ pin-project = "1.1"
 async-stream = "0.3"
 thiserror = "2.0"
 url = "2.5"
+zstd = "0.13"
 
 [dev-dependencies]
 dirs = "6.0"

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,7 +1,6 @@
 use std::{boxed, env, error, fs, io, path::Path, result::Result};
 
-use docker_registry::render;
-use docker_registry::v2::manifest::Manifest;
+use docker_registry::{render, v2::manifest::Manifest};
 use futures::future::try_join_all;
 use tracing::{error, info, warn};
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,9 +1,9 @@
 use std::{boxed, env, error, fs, io, path::Path, result::Result};
 
 use docker_registry::render;
+use docker_registry::v2::manifest::Manifest;
 use futures::future::try_join_all;
 use tracing::{error, info, warn};
-use docker_registry::v2::manifest::Manifest;
 
 #[tokio::main]
 async fn main() -> Result<(), boxed::Box<dyn error::Error>> {
@@ -95,7 +95,7 @@ async fn run(
   let client = client.authenticate(&[&login_scope]).await?;
   let manifest = client.get_manifest(image, version).await?;
 
-  let manifest = if let Manifest::ML(manifest_list) = &manifest  {
+  let manifest = if let Manifest::ML(manifest_list) = &manifest {
     let x = &manifest_list.manifests[0];
     let (m, _) = client.get_manifest_and_ref(image, &x.digest).await?;
     m

--- a/examples/image_new.rs
+++ b/examples/image_new.rs
@@ -1,0 +1,137 @@
+use docker_registry::render;
+use docker_registry::render::LayerBlob;
+use docker_registry::v2::manifest::Manifest;
+use futures::future::try_join_all;
+use std::{boxed, env, error, fs, io, path::Path, result::Result};
+use tracing::{error, info, warn};
+
+#[tokio::main]
+async fn main() -> Result<(), boxed::Box<dyn error::Error>> {
+  let registry = match std::env::args().nth(1) {
+    Some(x) => x,
+    None => "quay.io".into(),
+  };
+
+  let image = match std::env::args().nth(2) {
+    Some(x) => x,
+    None => "coreos/etcd".into(),
+  };
+
+  let version = match std::env::args().nth(3) {
+    Some(x) => x,
+    None => "v3.6.5".into(),
+  };
+
+  let path_string = format!("{}:{}", &image, &version).replace("/", "_");
+  let path = Path::new(&path_string);
+  if path.exists() {
+    let msg = format!("path {:?} already exists", &path);
+    match std::env::var("IMAGE_OVERWRITE") {
+      Ok(value) if value == "true" => {
+        std::fs::remove_dir_all(path)?;
+        eprintln!("{msg}, removing.");
+      }
+      _ => return Err(format!("{msg}, exiting.").into()),
+    }
+  };
+
+  info!("[{registry}] downloading image {image}:{version}");
+
+  let mut user = None;
+  let mut password = None;
+  let home = dirs::home_dir().unwrap();
+  let cfg = fs::File::open(home.join(".docker/config.json"));
+  if let Ok(fp) = cfg {
+    let creds = docker_registry::get_credentials(io::BufReader::new(fp), &registry);
+    if let Ok(user_pass) = creds {
+      user = user_pass.0;
+      password = user_pass.1;
+    } else {
+      warn!("[{registry}] no credentials found in config.json");
+    }
+  } else {
+    user = env::var("DOCKER_REGISTRY_USER").ok();
+    if user.is_none() {
+      warn!("[{registry}] no $DOCKER_REGISTRY_USER for login user");
+    }
+    password = env::var("DOCKER_REGISTRY_PASSWD").ok();
+    if password.is_none() {
+      warn!("[{registry}] no $DOCKER_REGISTRY_PASSWD for login password");
+    }
+  };
+
+  let res = run(&registry, &image, &version, user, password, path).await;
+
+  if let Err(e) = res {
+    error!("[{registry}] {e}");
+    std::process::exit(1);
+  };
+
+  Ok(())
+}
+
+async fn run(
+  registry: &str,
+  image: &str,
+  version: &str,
+  user: Option<String>,
+  passwd: Option<String>,
+  path: &Path,
+) -> Result<(), boxed::Box<dyn error::Error>> {
+  tracing_subscriber::fmt()
+    .pretty()
+    .with_max_level(tracing::Level::INFO)
+    .init();
+
+  let client = docker_registry::v2::Client::configure()
+    .registry(registry)
+    .insecure_registry(false)
+    .username(user)
+    .password(passwd)
+    .build()?;
+
+  let login_scope = format!("repository:{image}:pull");
+
+  let client = client.authenticate(&[&login_scope]).await?;
+  let manifest = client.get_manifest(image, version).await?;
+
+  for x in manifest.architectures().unwrap() {
+    println!("Architecture: {}", x);
+  }
+
+  let manifest = if let Manifest::ML(manifest_list) = &manifest {
+    let x = &manifest_list.manifests[0];
+    let (m, _) = client.get_manifest_and_ref(image, &x.digest).await?;
+    m
+  } else {
+    manifest
+  };
+
+  let layers_digests = manifest.layers(Some("amd64"))?;
+
+  info!("{} -> got {} layer(s)", &image, layers_digests.len(),);
+
+  let blob_futures = layers_digests
+    .iter()
+    .map(|layer_digest| client.get_blob_from_layer(image, layer_digest))
+    .collect::<Vec<_>>();
+
+  let layer_blobs = try_join_all(blob_futures)
+    .await?
+    .into_iter()
+    .map(|(bytes, media_type)| LayerBlob {
+      bytes,
+      media_type: Some(media_type),
+    })
+    .collect::<Vec<_>>();
+
+  println!("Downloaded {} layers", layer_blobs.len());
+
+  tokio::fs::create_dir(path).await?;
+  let can_path = path.canonicalize()?;
+
+  info!("Unpacking layers to {:?}", &can_path);
+  render::unpack_layers(&layer_blobs, &can_path)?;
+
+  Ok(())
+}

--- a/examples/image_new.rs
+++ b/examples/image_new.rs
@@ -1,8 +1,7 @@
-use docker_registry::render;
-use docker_registry::render::LayerBlob;
-use docker_registry::v2::manifest::Manifest;
-use futures::future::try_join_all;
 use std::{boxed, env, error, fs, io, path::Path, result::Result};
+
+use docker_registry::{render, render::LayerBlob, v2::manifest::Manifest};
+use futures::future::try_join_all;
 use tracing::{error, info, warn};
 
 #[tokio::main]

--- a/src/render.rs
+++ b/src/render.rs
@@ -3,9 +3,17 @@
 // Docker image format is specified at
 // https://github.com/moby/moby/blob/v17.05.0-ce/image/spec/v1.md
 
+use std::io::{ErrorKind, Read};
 use std::{fs, io, path};
-
+use std::path::Path;
 use libflate::gzip;
+use tar::EntryType;
+
+#[derive(Debug)]
+pub struct LayerBlob {
+  pub bytes: Vec<u8>,
+  pub media_type: Option<String>,
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum RenderError {
@@ -19,57 +27,73 @@ pub enum RenderError {
 ///
 /// Layers must be provided as gzip-compressed tar archives, with lower layers
 /// coming first. Target directory must be an existing absolute path.
-pub fn unpack(layers: &[Vec<u8>], target_dir: &path::Path) -> Result<(), RenderError> {
-  _unpack(layers, target_dir, |mut archive, target_dir| {
-    Ok(archive.unpack(target_dir)?)
-  })
+pub fn unpack(layers: &[Vec<u8>], target_dir: &Path) -> Result<(), RenderError> {
+  filter_unpack(layers, target_dir, |_| { true })
+}
+
+/// Unpack an ordered list of layers-blobs to a target directory.
+///
+/// Layers must be provided as gzip- or zstd-compressed tar archives, with lower layers
+/// coming first. Target directory must be an existing absolute path.
+pub fn unpack_layers(layers: &[LayerBlob], target_dir: &Path) -> Result<(), RenderError> {
+  filter_unpack_layers(layers, target_dir,|_| { true } )
+}
+
+pub fn filter_unpack<P>(layers: &[Vec<u8>], target_dir: &Path, predicate: P) -> Result<(), RenderError>
+where
+    P: Fn(&Path) -> bool,
+{
+  let layers = layers
+      .into_iter()
+      .map(|b| LayerBlob { bytes: b.clone(), media_type: None })
+      .collect::<Vec<_>>();
+
+  filter_unpack_layers(layers.as_slice(), target_dir, predicate)
 }
 
 /// Unpack an ordered list of layers to a target directory, filtering
 /// file entries by path.
 ///
-/// Layers must be provided as gzip-compressed tar archives, with lower layers
+/// Layers must be provided as gzip- or zstd-compressed tar archives, with lower layers
 /// coming first. Target directory must be an existing absolute path.
-pub fn filter_unpack<P>(layers: &[Vec<u8>], target_dir: &path::Path, predicate: P) -> Result<(), RenderError>
+pub fn filter_unpack_layers<P>(layers: &[LayerBlob], target_dir: &Path, predicate: P) -> Result<(), RenderError>
 where
-  P: Fn(&path::Path) -> bool,
+  P: Fn(&Path) -> bool,
 {
-  _unpack(layers, target_dir, |mut archive, target_dir| {
-    for entry in archive.entries()? {
-      let mut entry = entry?;
-      let path = entry.path()?;
-
-      if predicate(&path) {
-        entry.unpack_in(target_dir)?;
-      }
-    }
-
-    Ok(())
-  })
+  for l in layers {
+    _unpack_layer(l, target_dir, &predicate)?;
+  }
+  Ok(())
 }
 
-fn _unpack<U>(layers: &[Vec<u8>], target_dir: &path::Path, unpacker: U) -> Result<(), RenderError>
-where
-  U: Fn(tar::Archive<gzip::Decoder<&[u8]>>, &path::Path) -> Result<(), RenderError>,
+fn _unpack_archive<'a, P>(dst: &Path, archive: &mut tar::Archive<Box<dyn Read + 'a>>, predicate: P) -> io::Result<()>
+where P: Fn(&Path) -> bool
 {
-  if !target_dir.is_absolute() || !target_dir.exists() || !target_dir.is_dir() {
-    return Err(RenderError::WrongTargetPath(target_dir.to_path_buf()));
-  }
-  for l in layers {
-    // Unpack layers
-    let gz_dec = gzip::Decoder::new(l.as_slice())?;
-    let mut archive = tar::Archive::new(gz_dec);
-    archive.set_preserve_permissions(true);
-    archive.set_unpack_xattrs(true);
-    unpacker(archive, target_dir)?;
+  if dst.symlink_metadata().is_err() {
+    fs::create_dir_all(&dst)
+        .map_err(|e| io::Error::new( ErrorKind::Other, format!("failed to create `{}`. {}", dst.display(), e)))?
+  };
 
-    // Clean whiteouts
-    let gz_dec = gzip::Decoder::new(l.as_slice())?;
-    let mut archive = tar::Archive::new(gz_dec);
-    for entry in archive.entries()? {
-      let file = entry?;
+  // Canonicalizing the dst directory will prepend the path with '\\?\'
+  // on windows which will allow windows APIs to treat the path as an
+  // extended-length path with a 32,767 character limit. Otherwise all
+  // unpacked paths over 260 characters will fail on creation with a
+  // NotFound exception.
+  let dst = &dst.canonicalize().unwrap_or(dst.to_path_buf());
+
+  // Delay any directory entries until the end (they will be created if needed by
+  // descendants), to ensure that directory permissions do not interfer with descendant
+  // extraction.
+  let mut directories = Vec::new();
+  for entry in archive.entries()? {
+    let mut file = entry.map_err(|e| io::Error::new(ErrorKind::Other, format!("failed to iterate over archive. {}", e)))?;
+    if file.header().entry_type() == EntryType::Directory {
+      directories.push(file);
+    } else {
+      // Check for whiteouts else unpack file
       let path = file.path()?;
-      let parent = path.parent().unwrap_or_else(|| path::Path::new("/"));
+      let parent = path.parent().unwrap_or_else(|| Path::new("/"));
+
       if let Some(fname) = path.file_name() {
         let wh_name = fname.to_string_lossy();
         if wh_name == ".wh..wh..opq" {
@@ -79,16 +103,64 @@ where
 
           // Remove real file behind whiteout
           let real_name = wh_name.trim_start_matches(".wh.");
-          let abs_real_path = target_dir.join(&rel_parent).join(real_name);
+          let abs_real_path = dst.join(&rel_parent).join(real_name);
           remove_whiteout(abs_real_path)?;
 
           // Remove whiteout place-holder
-          let abs_wh_path = target_dir.join(&rel_parent).join(fname);
+          let abs_wh_path = dst.join(&rel_parent).join(fname);
           remove_whiteout(abs_wh_path)?;
-        };
+        } else {
+          if predicate(&path) {
+            //println!("unpack {}", file.path()?.display());
+            file.unpack_in(dst)?;
+          }
+        }
       }
     }
   }
+
+  // Apply the directories.
+  //
+  // Note: the order of application is important to permissions. That is, we must traverse
+  // the filesystem graph in topological ordering or else we risk not being able to create
+  // child directories within those of more restrictive permissions. See [0] for details.
+  //
+  // [0]: <https://github.com/alexcrichton/tar-rs/issues/242>
+  directories.sort_by(|a, b| b.path_bytes().cmp(&a.path_bytes()));
+  for mut dir in directories {
+    dir.unpack_in(dst)?;
+  }
+
+  Ok(())
+}
+
+fn _unpack_layer<'a, P>(layer: &'a LayerBlob, target_dir: &Path, predicate: &P) -> Result<(), RenderError>
+where P: Fn(&Path) -> bool
+{
+  if !target_dir.is_absolute() || !target_dir.exists() || !target_dir.is_dir() {
+    return Err(RenderError::WrongTargetPath(target_dir.to_path_buf()));
+  }
+
+  let decompressed_reader: Box<dyn Read + 'a> = {
+    let l = &layer.bytes;
+
+    match layer.media_type {
+      Some(ref media_type) if media_type.ends_with("+zstd") => {
+        Box::new(zstd::Decoder::new(l.as_slice())?)
+      }
+      _ => {
+        Box::new(gzip::Decoder::new(l.as_slice())?)
+      }
+    }
+  };
+
+  // Unpack layers
+  let mut archive = tar::Archive::new(decompressed_reader);
+  archive.set_preserve_permissions(true);
+  archive.set_unpack_xattrs(true);
+
+  _unpack_archive(target_dir, &mut archive, predicate)?;
+
   Ok(())
 }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,11 +2,9 @@
 
 // Docker image format is specified at
 // https://github.com/moby/moby/blob/v17.05.0-ce/image/spec/v1.md
+use std::{fs, io, io::Read, path, path::Path};
 
 use libflate::gzip;
-use std::io::Read;
-use std::path::Path;
-use std::{fs, io, path};
 use tar::EntryType;
 
 #[derive(Debug)]

--- a/src/v2/blobs.rs
+++ b/src/v2/blobs.rs
@@ -1,6 +1,5 @@
 use std::pin::Pin;
 
-use crate::v2::manifest::Layer;
 use bytes::Bytes;
 use futures::{
   stream::Stream,
@@ -12,7 +11,7 @@ use reqwest::{self, Method, StatusCode};
 
 use crate::{
   errors::{Error, Result},
-  v2::*,
+  v2::{manifest::Layer, *},
 };
 
 impl Client {

--- a/src/v2/manifest/manifest_schema1.rs
+++ b/src/v2/manifest/manifest_schema1.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
-use crate::v2::manifest::Layer;
 use serde::{Deserialize, Serialize};
+
+use crate::v2::manifest::Layer;
 
 /// Manifest version 2 schema 1, signed.
 ///

--- a/src/v2/manifest/manifest_schema1.rs
+++ b/src/v2/manifest/manifest_schema1.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use crate::v2::manifest::Layer;
 
 /// Manifest version 2 schema 1, signed.
 ///
@@ -44,8 +45,23 @@ impl ManifestSchema1Signed {
   /// List digests of all layers referenced by this manifest.
   ///
   /// The returned layers list is ordered starting with the base image first.
-  pub fn get_layers(&self) -> Vec<String> {
+  pub fn get_layers_digests(&self) -> Vec<String> {
     self.fs_layers.iter().rev().map(|l| l.blob_sum.clone()).collect()
+  }
+
+  /// List of all layers referenced by this manifest.
+  ///
+  /// The returned layers list is ordered starting with the base image first.
+  pub fn get_layers(&self) -> Vec<Layer> {
+    self.fs_layers
+        .iter()
+        .map(|l| {
+          Layer {
+            media_type: "application/vnd.docker.image.rootfs.diff.tar.gzip".to_string(),
+            digest: l.blob_sum.clone(),
+          }
+        })
+        .collect()
   }
 
   /// Get a collection of all image labels stored in the history array of this manifest.

--- a/src/v2/manifest/manifest_schema1.rs
+++ b/src/v2/manifest/manifest_schema1.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
 use crate::v2::manifest::Layer;
+use serde::{Deserialize, Serialize};
 
 /// Manifest version 2 schema 1, signed.
 ///
@@ -53,15 +53,14 @@ impl ManifestSchema1Signed {
   ///
   /// The returned layers list is ordered starting with the base image first.
   pub fn get_layers(&self) -> Vec<Layer> {
-    self.fs_layers
-        .iter()
-        .map(|l| {
-          Layer {
-            media_type: "application/vnd.docker.image.rootfs.diff.tar.gzip".to_string(),
-            digest: l.blob_sum.clone(),
-          }
-        })
-        .collect()
+    self
+      .fs_layers
+      .iter()
+      .map(|l| Layer {
+        media_type: "application/vnd.docker.image.rootfs.diff.tar.gzip".to_string(),
+        digest: l.blob_sum.clone(),
+      })
+      .collect()
   }
 
   /// Get a collection of all image labels stored in the history array of this manifest.

--- a/src/v2/manifest/manifest_schema2.rs
+++ b/src/v2/manifest/manifest_schema2.rs
@@ -4,9 +4,8 @@ use log::trace;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
-use crate::errors::Result;
 pub use crate::v2::ApiErrors;
-use crate::v2::manifest::Layer;
+use crate::{errors::Result, v2::manifest::Layer};
 
 /// Manifest version 2 schema 2.
 ///

--- a/src/v2/manifest/manifest_schema2.rs
+++ b/src/v2/manifest/manifest_schema2.rs
@@ -138,15 +138,15 @@ impl ManifestSchema2 {
   ///
   /// The returned layers list is ordered starting with the base image first.
   pub fn get_layers(&self) -> Vec<Layer> {
-    self.manifest_spec.layers
-        .iter()
-        .map(|l| {
-          Layer {
-            media_type: l.media_type.clone(),
-            digest: l.digest.clone(),
-          }
-        })
-        .collect()
+    self
+      .manifest_spec
+      .layers
+      .iter()
+      .map(|l| Layer {
+        media_type: l.media_type.clone(),
+        digest: l.digest.clone(),
+      })
+      .collect()
   }
 
   /// Get the architecture from the config
@@ -185,13 +185,13 @@ impl ManifestList {
 
   /// Get `Layer` structs all the manifest images in the ManifestList
   pub fn get_layers(&self) -> Vec<Layer> {
-    self.manifests
-        .iter()
-        .map(|mo| {
-          Layer {
-            media_type: mo.media_type.clone(),
-            digest: mo.digest.clone(),
-          }
-        }).collect()
+    self
+      .manifests
+      .iter()
+      .map(|mo| Layer {
+        media_type: mo.media_type.clone(),
+        digest: mo.digest.clone(),
+      })
+      .collect()
   }
 }

--- a/src/v2/manifest/manifest_schema2.rs
+++ b/src/v2/manifest/manifest_schema2.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::Result;
 pub use crate::v2::ApiErrors;
+use crate::v2::manifest::Layer;
 
 /// Manifest version 2 schema 2.
 ///
@@ -129,8 +130,23 @@ impl ManifestSchema2 {
   /// List digests of all layers referenced by this manifest.
   ///
   /// The returned layers list is ordered starting with the base image first.
-  pub fn get_layers(&self) -> Vec<String> {
+  pub fn get_layer_digests(&self) -> Vec<String> {
     self.manifest_spec.layers.iter().map(|l| l.digest.clone()).collect()
+  }
+
+  /// List of all layers referenced by this manifest.
+  ///
+  /// The returned layers list is ordered starting with the base image first.
+  pub fn get_layers(&self) -> Vec<Layer> {
+    self.manifest_spec.layers
+        .iter()
+        .map(|l| {
+          Layer {
+            media_type: l.media_type.clone(),
+            digest: l.digest.clone(),
+          }
+        })
+        .collect()
   }
 
   /// Get the architecture from the config
@@ -165,5 +181,17 @@ impl ManifestList {
   /// Get the digest for all the manifest images in the ManifestList
   pub fn get_digests(&self) -> Vec<String> {
     self.manifests.iter().map(|mo| mo.digest()).collect()
+  }
+
+  /// Get `Layer` structs all the manifest images in the ManifestList
+  pub fn get_layers(&self) -> Vec<Layer> {
+    self.manifests
+        .iter()
+        .map(|mo| {
+          Layer {
+            media_type: mo.media_type.clone(),
+            digest: mo.digest.clone(),
+          }
+        }).collect()
   }
 }


### PR DESCRIPTION
## Description and Motivation
With OCI image-spec 1.1.0 the compression algorithm 'zstd' was introduced.
This pull-requests implement the support of zstd compressed image-layers in docker-registry.

## How Has This Been Tested?
The image ghcr.io/ublue-os/fedora-toolbox:latest was used for tests with zstd layers
