### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Continuous integration
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/clowdhaus/docker-registry/security/code-scanning/4](https://github.com/clowdhaus/docker-registry/security/code-scanning/4)

To fix the problem, explicitly set the `permissions` block in the workflow file. The most secure and maintainable way is to set it at the top level of the workflow, applying least privilege to all jobs unless overridden. From inspection, none of the jobs require any more than read access to repository contents—they only check out code and run checks/lints/tests, and do not interact with GitHub APIs to open PRs, push code, etc. Therefore, the permissions block should specify:

```yaml
permissions:
  contents: read
```

This should be added directly after the `name` field (after line 1), before the `on:` block on line 3. No changes are needed within jobs unless one needs broader privileges (which is not evident from the code shown).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
