### PR TITLE
Potential fix for code scanning alert no. 6: Failure to use HTTPS URLs

### DIFF
--- a/src/v2/config.rs
+++ b/src/v2/config.rs
@@ -76,11 +76,21 @@ impl Config {
 
   /// Return a `Client` to interact with a v2 registry.
   pub fn build(self) -> Result<Client> {
-    let base = if self.insecure_registry {
-      "http://".to_string() + &self.index
+    // Only allow HTTP if registry is localhost/127.0.0.1
+    if self.insecure_registry {
+      let index = self.index.to_ascii_lowercase();
+      if !(index == "localhost" || index.starts_with("localhost:")
+            || index == "127.0.0.1" || index.starts_with("127.0.0.1:")) {
+        return Err(crate::errors::Error::Other(
+          format!("Refusing to connect to non-local registry over HTTP: {}", self.index)
+        ));
+      }
+      trace!("Warning: using insecure HTTP connection to local registry");
+      let base = "http://".to_string() + &self.index;
+      base
     } else {
       "https://".to_string() + &self.index
-    };
+    }
     trace!(
       "Built client for {:?}: endpoint {:?} - user {:?}",
       self.index, base, self.username


### PR DESCRIPTION
Potential fix for [https://github.com/clowdhaus/docker-registry/security/code-scanning/6](https://github.com/clowdhaus/docker-registry/security/code-scanning/6)

The best way to remediate this is to prevent the use of HTTP by default, and discourage or disable HTTP usage except in clearly-marked/test configurations. Changes required:
1. **Change the default for `insecure_registry` to `false`.** (Already set, but highlight this in docs for clarity.)
2. **Emit a warning or error when `insecure_registry` is set to `true` for public registries.** Optionally, block non-localhost/loopback values.
3. **Document and gate the use of HTTP**: Require explicit opt-in, and annotate that HTTP is insecure and not recommended outside local/test scenarios.
4. **Best single fix:** Prevent the construction of HTTP URLs for public registries by raising an error or warning if `insecure_registry` is true and the registry hostname is not localhost/127.0.0.1.

Concrete implementation steps:
- In src/v2/config.rs, within the `build()` method, before constructing the URL, check if `insecure_registry` is true and if `self.index` points to a non-localhost host (not 127.0.0.1 or localhost). If so, return an error.
- If the registry is localhost, allow HTTP when `insecure_registry` is true.
- Optionally, raise a log warning even for localhost when using HTTP.
- No imports of external libraries are necessary; standard library string operations suffice.

Edits will only be to regions in src/v2/config.rs shown above, specifically lines around the URL schema selection in the `build()` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
