### PR TITLE
fix: allow Basic auth realm values without quotes

### DIFF
--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -136,7 +136,7 @@ const REGEX: &str = r#"(?x)\s*
     \s*
         =
     \s*
-        "(?P<value>[^"]+)"
+        "?(?P<value>[^"]+)"?
     \s*
 )
 "#;
@@ -395,6 +395,7 @@ mod tests {
       HeaderValue::from_str(&format!(r#"BASIC realm="{realm}""#)).unwrap(),
       HeaderValue::from_str(&format!(r#"Basic Realm="{realm}""#)).unwrap(),
       HeaderValue::from_str(&format!(r#"Basic REALM="{realm}""#)).unwrap(),
+      HeaderValue::from_str(&format!(r#"Basic realm={realm}"#)).unwrap(),
     ]
     .iter()
     {


### PR DESCRIPTION
Some clients send the `WWW-Authenticate` header in the form:

`< Www-Authenticate: Basic realm=Reducated`

instead of the standard:

`< Www-Authenticate: Basic realm="Reducated"`

To ensure compatibility, loosen the parsing regex to accept realm values that are not wrapped in quotes when processing the authentication header.

