### PR TITLE
chore: Update sha2 to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,13 +44,14 @@ strum = { version = "0.28", features = ["derive"] }
 tar = "0.4"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream"] }
-sha2 = "0.10"
+sha2 = "0.11"
 bytes = "1.9"
 pin-project = "1.1"
 async-stream = "0.3"
 thiserror = "2.0"
 url = "2.5"
 zstd = "0.13"
+base16ct = "1.0.0"
 
 [dev-dependencies]
 dirs = "6.0"

--- a/src/v2/content_digest.rs
+++ b/src/v2/content_digest.rs
@@ -1,5 +1,6 @@
 use std::str;
 
+use base16ct::HexDisplay;
 /// Implements types and methods for content verification
 use sha2::{self, Digest};
 
@@ -92,7 +93,7 @@ impl DigestAlgorithm {
     let (algo, digest) = match self {
       DigestAlgorithm::Sha256(hash) => ("sha256", hash.finalize()),
     };
-    format!("{}:{:x}", algo, &digest)
+    format!("{}:{:x}", algo, HexDisplay(&digest))
   }
 }
 

--- a/tests/mock/blobs_download.rs
+++ b/tests/mock/blobs_download.rs
@@ -63,7 +63,7 @@ async fn test_blobs_hasnot_layer() {
 async fn get_blobs_succeeds_with_consistent_layer() -> Fallible<()> {
   let name = "my-repo/my-image";
   let blob = b"hello";
-  let digest = format!("sha256:{:x}", sha2::Sha256::digest(blob));
+  let digest = format!("sha256:{:x}", base16ct::HexDisplay(&sha2::Sha256::digest(blob)));
   let ep = format!("/v2/{name}/blobs/{digest}");
 
   let mut server = mockito::Server::new_async().await;
@@ -96,7 +96,7 @@ async fn get_blobs_fails_with_inconsistent_layer() -> Fallible<()> {
   let name = "my-repo/my-image";
   let blob = b"hello";
   let blob2 = b"hello2";
-  let digest = format!("sha256:{:x}", sha2::Sha256::digest(blob));
+  let digest = format!("sha256:{:x}", base16ct::HexDisplay(&sha2::Sha256::digest(blob)));
   let ep = format!("/v2/{name}/blobs/{digest}");
 
   let mut server = mockito::Server::new_async().await;
@@ -130,7 +130,7 @@ async fn get_blobs_fails_with_inconsistent_layer() -> Fallible<()> {
 async fn get_blobs_stream() -> Fallible<()> {
   let name = "my-repo/my-image";
   let blob = b"hello";
-  let digest = format!("sha256:{:x}", sha2::Sha256::digest(blob));
+  let digest = format!("sha256:{:x}", base16ct::HexDisplay(&sha2::Sha256::digest(blob)));
   let ep = format!("/v2/{name}/blobs/{digest}");
 
   let mut server = mockito::Server::new_async().await;


### PR DESCRIPTION
There is a breaking change because they changed from generic-array to hybrid-array, see https://github.com/RustCrypto/hybrid-array/issues/201.

According to the issue, the recommended solution is to use the base16ct crate instead, so that's what this commit does.

## Motivation and Context

Feel free to ignore this for now, maybe they end up adding it in hybrid-array, but since I happened to come across this, I figured it might save you some time in case you do want to update.

## How Has This Been Tested?

`cargo test`, plus a simple CLI against a private registry behaves identically with or without this change.
